### PR TITLE
Prevent housing creation depending on trip status

### DIFF
--- a/apps/web/assets/stylesheets/components/_banners.scss
+++ b/apps/web/assets/stylesheets/components/_banners.scss
@@ -29,6 +29,7 @@
 
   .action-container {
     position: absolute;
+    z-index: 10;
     left: 0;
     right: 0;
     bottom: -23px; // [button-action] half of the height of the button
@@ -49,8 +50,8 @@
 
   .details-container {
     position: relative;
-    margin-bottom: 23px; // [button-action] half of the height of the button
-    padding: 2em 0;
+    padding-top: 2em;
+    padding-bottom: 3em;
 
     @media (min-width: $screen-sm-min) {
       &:after {

--- a/apps/web/controllers/trips/housings/authorization.rb
+++ b/apps/web/controllers/trips/housings/authorization.rb
@@ -7,7 +7,11 @@ module Web
 
         def load_trip_and_authorize
           @trip = TripRepository.new.find_with_organizers(params[:trip_id])
-          halt 401 unless @trip && (user_organizer? || user_authorized?)
+          halt 401 unless @trip && future_trip? && (user_organizer? || user_authorized?)
+        end
+
+        def future_trip?
+          @trip.starting_on >= Date.today
         end
 
         def user_organizer?

--- a/apps/web/templates/trips/show.html.erb
+++ b/apps/web/templates/trips/show.html.erb
@@ -15,14 +15,16 @@
         </ul>
       </div>
     </div>
-    <div class="action-container">
-      <%=
-        link_to routes.new_trip_housing_path(trip.id), class: 'btn btn-primary' do
-          i(class: "fa fa-plus-circle", 'aria-hidden' => true)
-          text 'New place'
-        end
-      %>
-    </div>
+    <% if trip.future? %>
+      <div class="action-container">
+        <%=
+          link_to routes.new_trip_housing_path(trip.id), class: 'btn btn-primary' do
+            i(class: "fa fa-plus-circle", 'aria-hidden' => true)
+            text 'New place'
+          end
+        %>
+      </div>
+    <% end %>
   </div>
 </div>
 <div class="container">


### PR DESCRIPTION
If trip is not in the future:

- Ensure that housing actions are not accessed
- Do not display housing creation button