### PR TITLE
Use ROM query syntax instead of Sequel when possible

### DIFF
--- a/lib/housing_list/repositories/housing_repository.rb
+++ b/lib/housing_list/repositories/housing_repository.rb
@@ -9,7 +9,7 @@ class HousingRepository < Hanami::Repository
   end
 
   def for_trip_sorted_by_most_recent(trip_id)
-    wrap_user.where(trip_id: trip_id).order(Sequel.desc(:created_at)).as(Housing).to_a
+    wrap_user.where(trip_id: trip_id).order { created_at.desc }.as(Housing).to_a
   end
 
   private

--- a/lib/housing_list/repositories/trip_repository.rb
+++ b/lib/housing_list/repositories/trip_repository.rb
@@ -22,7 +22,7 @@ class TripRepository < Hanami::Repository
     when :completed
       all_trips = all_trips.
         where { ending_on < Date.today }.
-        order(Sequel.desc(:ending_on))
+        order { ending_on.desc }
     end
 
     return all_trips.as(TripWithStats).to_a
@@ -55,13 +55,13 @@ class TripRepository < Hanami::Repository
 
   def trips_with_stats
     relations[:trips].
-      left_join(:housings).
+      left_join(relations[:housings]). # auto qualifies the columns
       select_append {
         [
-          int::count(Sequel.qualify(:housings, :id)).as(:housings_count),
-          int::avg(Sequel.qualify(:housings, :total_price)).as(:total_price_avg),
-          int::min(Sequel.qualify(:housings, :total_price)).as(:total_price_min),
-          int::max(Sequel.qualify(:housings, :total_price)).as(:total_price_max)
+          int::count('housings.id').as(:housings_count),
+          int::avg(:total_price).as(:total_price_avg),
+          int::min(:total_price).as(:total_price_min),
+          int::max(:total_price).as(:total_price_max)
         ]
       }.
       group(:id)


### PR DESCRIPTION
Most of the time, it's easier to read a ROM query than a Sequel query. So let's try to always use ROM query syntax when possible.