### PR TITLE
Fix user joining a trip

### DIFF
--- a/apps/web/controllers/trips/authorization.rb
+++ b/apps/web/controllers/trips/authorization.rb
@@ -23,8 +23,8 @@ module Web
         Web::Trips::Authorizations::Invite.new(user, trip).granted?
       end
 
-      def join?
-        Web::Trips::Authorizations::Join.new(user, trip).granted?
+      def join?(token=nil)
+        Web::Trips::Authorizations::Join.new(user, trip, token).granted?
       end
 
       def housing_creation?

--- a/apps/web/controllers/trips/authorizations/join.rb
+++ b/apps/web/controllers/trips/authorizations/join.rb
@@ -3,20 +3,25 @@ module Web::Trips::Authorizations
     include Base
 
     private
-    attr_reader :trip, :user
+    attr_reader :token, :trip, :user
 
     public
 
-    def initialize(user, trip)
-      @user = user
-      @trip = trip
+    def initialize(user, trip, token)
+      @user  = user
+      @trip  = trip
+      @token = token
     end
 
     def granted?
-      visitor? || (user_signed_in? && !user_organizer?)
+      token_valid? && (visitor? || (user_signed_in? && !user_organizer?))
     end
 
     private
+
+    def token_valid?
+      !token.to_s.empty? && token == trip.invitation_token
+    end
 
     def visitor?
       !user

--- a/apps/web/controllers/trips/join.rb
+++ b/apps/web/controllers/trips/join.rb
@@ -11,6 +11,7 @@ module Web::Controllers::Trips
         organizer_id: current_user.id
       )
 
+      session[:invitation_token] = nil
       redirect_to routes.trip_path(@trip.id)
     end
 
@@ -22,7 +23,7 @@ module Web::Controllers::Trips
 
     def authorize
       authorization = Web::Trips::Authorization.new(current_user, @trip)
-      halt 401 unless authorization.join?
+      halt 401 unless authorization.join?(session[:invitation_token])
     end
   end
 end

--- a/apps/web/controllers/trips/show.rb
+++ b/apps/web/controllers/trips/show.rb
@@ -6,10 +6,12 @@ module Web::Controllers::Trips
     before :load_trip
     before :authorize
     before :store_current_location
+    before :store_invitation_token
 
     expose :authorization
     expose :housing_stats
     expose :housings
+    expose :invitation_token
     expose :trip
 
     def call(params)
@@ -32,6 +34,13 @@ module Web::Controllers::Trips
       else
         halt 404
       end
+    end
+
+    def store_invitation_token
+      @invitation_token = params[:token]
+      return unless @invitation_token
+
+      session[:invitation_token] = @invitation_token
     end
   end
 end

--- a/apps/web/templates/trips/show.html.erb
+++ b/apps/web/templates/trips/show.html.erb
@@ -26,7 +26,7 @@
         </ul>
       </div>
     </div>
-    <% if authorization.join? %>
+    <% if authorization.join?(invitation_token) %>
       <div class="action-container">
         <%=
           form_for :user, routes.join_trip_path(trip.id), method: :patch do


### PR DESCRIPTION
Always check the validity of the token before adding a user as organizer of a trip.