### PR TITLE
Fix configuration of Bugsnag

### DIFF
--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -92,7 +92,9 @@ module Web
       # Configure Rack middleware for this application
       #
       # middleware.use Rack::Protection
-      middleware.use Bugsnag::Rack
+      # middleware.use Bugsnag::Rack # FIXME: Try to enable bugsnag here instead
+                                     #        of from within config.ru
+                                     #        Let's wait for Hanami 1.2
 
       # Default format for the requests that don't specify an HTTP_ACCEPT header
       # Argument: A symbol representation of a mime type, defaults to :html

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
 require './config/environment'
 
+use Bugsnag::Rack
 run Hanami.app


### PR DESCRIPTION
For now, when directly enabled from the web app, Bugsnag only reports errors that happen from within actions but not from within views or templates.

To fix that, we have to enable Bugsnag directly from config.ru

Hanami 1.2 will (really) support middlewares enabled from the app.