### PR TITLE
Change default redirect on user sign in

### DIFF
--- a/apps/web/controllers/users/sign_in.rb
+++ b/apps/web/controllers/users/sign_in.rb
@@ -22,7 +22,7 @@ module Web
       end
 
       def sign_in_and_redirect(user)
-        user_return_to           = session[:user_return_to] || routes.root_path
+        user_return_to           = session[:user_return_to] || routes.trips_path
         session[:user_id]        = user.id
         session[:user_return_to] = nil
 


### PR DESCRIPTION
By default, redirect to the user's trips page instead of the home page.